### PR TITLE
add results release

### DIFF
--- a/app/psifos/model/enums.py
+++ b/app/psifos/model/enums.py
@@ -38,6 +38,7 @@ class ElectionPublicEventEnum(ElectionEvenEnum):
     TALLY_COMPUTED = "tally_computed"
     DECRYPTION_RECIEVED = "decryption_recieved"
     DECRYPTIONS_COMBINED = "decryptions_combined"
+    RESULTS_RELEASED = "results_released"
 
 class ElectionAdminEventEnum(ElectionEvenEnum):
     VOTER_LOGIN = "voter_login"


### PR DESCRIPTION
## Titulo
Estado de resultados liberados

## Descripción
Se agrega un nuevo estado a las elecciones que corresponde a la acción de liberar los resultados, ahora cuando se combinan las desencriptaciones parciales se genera un nuevo paso manual para que los resultados sean liberados al publico.