### PR TITLE
Election multi group

### DIFF
--- a/app/psifos/model/models.py
+++ b/app/psifos/model/models.py
@@ -44,6 +44,7 @@ class Election(Base):
     obscure_voter_names = Column(Boolean, default=False, nullable=False)
     randomize_answer_order = Column(Boolean, default=False, nullable=False)
     normalization = Column(Boolean, default=False, nullable=False)
+    grouped = Column(Boolean, default=False, nullable=False)
     max_weight = Column(Integer, nullable=False)
 
     total_voters = Column(Integer, default=0)

--- a/app/psifos/model/schemas.py
+++ b/app/psifos/model/schemas.py
@@ -148,6 +148,7 @@ class ElectionBase(BaseModel):
     randomize_answer_order: bool | None
     private_p: bool | None
     normalization: bool | None
+    grouped: bool | None
 
 
 class ElectionOut(ElectionBase):


### PR DESCRIPTION
# Titulo
Elecciones con multiple grupo

# Descripción
Se quieren hacer elecciones con multiples grupos, categorizando a los votantes. Para lograr esto debemos separar el tally.

# Como probar
Se necesitan subir votantes donde su ultimo valor del archivo corresponde al nombre del grupo donde perteneces, si estos no tienen no se le asigna grupo (las elecciones abiertas no van con grupo)