### PR TITLE
add disable vote

### DIFF
--- a/app/psifos/model/crud.py
+++ b/app/psifos/model/crud.py
@@ -161,6 +161,10 @@ async def get_num_casted_votes(session: Session | AsyncSession, election_id: int
     voters = await get_voters_by_election_id(session=session, election_id=election_id)
     return len([v for v in voters if v.valid_cast_votes >= 1])
 
+async def get_num_counted_votes(session: Session | AsyncSession, election_id: int):
+    voters = await get_voters_by_election_id(session=session, election_id=election_id)
+    return len([v for v in voters if v.valid_cast_votes >= 1 and v.count_vote])
+
 
 async def count_cast_vote_by_date(session: Session | AsyncSession, init_date, end_date, election_id: int):
 

--- a/app/psifos/model/models.py
+++ b/app/psifos/model/models.py
@@ -82,6 +82,7 @@ class Voter(Base):
 
     valid_cast_votes = Column(Integer, default=0)
     invalid_cast_votes = Column(Integer, default=0)
+    count_vote = Column(Boolean, nullable=False)
     
     # One-to-one relationship
     cast_vote = relationship("CastVote", cascade="all, delete", backref="psifos_voter", uselist=False)

--- a/app/psifos/model/schemas.py
+++ b/app/psifos/model/schemas.py
@@ -120,6 +120,7 @@ class VoterOut(VoterBase):
     voter_login_id: str
     voter_name: str
     voter_weight: int
+    count_vote: bool
 
     class Config:
         orm_mode = True

--- a/app/psifos/routes.py
+++ b/app/psifos/routes.py
@@ -75,6 +75,10 @@ async def get_election_stats(short_name: str, session: Session | AsyncSession = 
             session=session,
             election_id=election.id
         ),
+        "num_count_votes": await crud.get_num_counted_votes(
+            session=session,
+            election_id=election.id
+        ),
         "total_voters": election.total_voters,
         "status": election.election_status,
         "name": election.short_name


### PR DESCRIPTION
## Titulo
Deshabilitar votos mediante el administrador

## Descripción
Se necesita poder deshabilitar votos para ciertos votantes y así no sean contabilizados en el cierre de la elección

## Desarrollo
Se decidió agregar un campo nuevo al modelo del votante llamado `count_vote`. Este atributo nuevo permitirá discriminar si su voto debe ser contabilizado al finalizar la elección (Al momento de generar el tally)

## Imagenes
### Vista de la tabla de administrador de votantes
![Captura desde 2023-10-16 12-12-15](https://github.com/clcert/psifos-frontend/assets/32551270/f6ee4297-b3f3-4786-88fe-d4ddcc9f747d)
### Configuración
![Captura desde 2023-10-16 12-12-32](https://github.com/clcert/psifos-frontend/assets/32551270/6497d58a-9fb4-4092-830b-3424ac20efd5)
### Tabla resultados finales
![Captura desde 2023-10-16 12-12-45](https://github.com/clcert/psifos-frontend/assets/32551270/a81b4218-e163-4823-b31d-c2b3fb6e67de)
### Portal de información
![Captura desde 2023-10-16 12-12-56](https://github.com/clcert/psifos-frontend/assets/32551270/833063c2-ac32-4ae3-98c9-26cba2e01f4f)