### PR TITLE
Psifos trustee

### DIFF
--- a/app/psifos/model/models.py
+++ b/app/psifos/model/models.py
@@ -51,6 +51,7 @@ class Election(Base):
     normalized = Column(Boolean, default=False, nullable=False)
     grouped_voters = Column(Boolean, default=False, nullable=False)
     max_weight = Column(Integer, nullable=False)
+    has_psifos_trustees = Column(Boolean, default=False, nullable=False)
 
     decryptions_uploaded = Column(Integer, default=0)
 

--- a/app/psifos/routes.py
+++ b/app/psifos/routes.py
@@ -518,9 +518,9 @@ async def check_election_status(short_name: str, session: Session | AsyncSession
     total_voters = len(voters)
     add_questions = len(questions) == 0 and election.status == ElectionStatusEnum.setting_up
     add_voters = len(voters) == 0 and election.voters_login_type == ElectionLoginTypeEnum.close_p and election.status == ElectionStatusEnum.setting_up
-    add_trustees = len(trustees) == 0 and election.status == ElectionStatusEnum.setting_up
+    add_trustees = len(trustees) == 0 and election.status == ElectionStatusEnum.setting_up and not election.has_psifos_trustees
 
-    key_generation_ready = election.status == ElectionStatusEnum.setting_up and (total_voters > 0 or election.voters_login_type != ElectionLoginTypeEnum.close_p) and total_trustees > 0 and not add_questions
+    key_generation_ready = election.status == ElectionStatusEnum.setting_up and (total_voters > 0 or election.voters_login_type != ElectionLoginTypeEnum.close_p) and (total_trustees > 0 or election.has_psifos_trustees) and not add_questions
 
     return {
         "add_voters": add_voters,


### PR DESCRIPTION
## Titulo
Psifos trustee

## Descripción
Esta nueva funcionalidad permite crear elecciones sin custodios de clave, es decir que psifos se encarga de toda la parte cryptografica en la generación de claves y desencriptaciones.